### PR TITLE
Replace SQLite strings with SQLiteData pointfree

### DIFF
--- a/DeviceValue/DeviceValue/FinancialFlowApp.swift
+++ b/DeviceValue/DeviceValue/FinancialFlowApp.swift
@@ -9,7 +9,7 @@ import ComposableArchitecture
 import Dependencies
 import HomeFeature
 import Models
-import SharingGRDB
+import SQLiteData
 import SwiftUI
 
 @main

--- a/DeviceValueApp/Package.swift
+++ b/DeviceValueApp/Package.swift
@@ -68,8 +68,8 @@ let package = Package(
             from: "7.2.0"
         ),
         .package(
-            url: "https://github.com/pointfreeco/sharing-grdb",
-            from: "0.1.0"
+            url: "https://github.com/pointfreeco/sqlite-data",
+            from: "1.3.0"
         ),
     ],
     targets: [
@@ -84,7 +84,7 @@ let package = Package(
                 "Utils",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "GRDB", package: "GRDB.swift"),
-                .product(name: "SharingGRDB", package: "sharing-grdb"),
+                .product(name: "SQLiteData", package: "sqlite-data"),
             ]
         ),
         .target(name:"BuildClient", dependencies: [
@@ -119,7 +119,7 @@ let package = Package(
                 "Utils",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "GRDB", package: "GRDB.swift"),
-                .product(name: "SharingGRDB", package: "sharing-grdb"),
+                .product(name: "SQLiteData", package: "sqlite-data"),
             ]
         ),
         .target(
@@ -130,14 +130,14 @@ let package = Package(
                 "Utils",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "GRDB", package: "GRDB.swift"),
-                .product(name: "SharingGRDB", package: "sharing-grdb"),
+                .product(name: "SQLiteData", package: "sqlite-data"),
             ]
         ),
         .target(
             name: "Models",
             dependencies: [
                 "Utils",
-                .product(name: "SharingGRDB", package: "sharing-grdb"),
+                .product(name: "SQLiteData", package: "sqlite-data"),
             ]
         ),
 
@@ -151,7 +151,7 @@ let package = Package(
                 "UIApplicationClient",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "GRDB", package: "GRDB.swift"),
-                .product(name: "SharingGRDB", package: "sharing-grdb"),
+                .product(name: "SQLiteData", package: "sqlite-data"),
             ]
         ),
         

--- a/DeviceValueApp/Sources/AddDeviceFeature/AddDeviceFeature.swift
+++ b/DeviceValueApp/Sources/AddDeviceFeature/AddDeviceFeature.swift
@@ -7,7 +7,7 @@ import Foundation
 import Generated
 import GRDB
 import Models
-import SharingGRDB
+import SQLiteData
 
 extension UsageRatePeriod {
   var localizedName: String {
@@ -53,10 +53,10 @@ public struct AddDeviceFeature: Sendable {
     var selectedUsageRatePeriodId: Int64
     var mode: Mode
 
-    @SharedReader(.fetchAll(sql: "SELECT * from \(Currency.databaseTableName)", animation: .default))
+    @Fetch(.fetchAll(sql: "SELECT * from \(Currency.databaseTableName)", animation: .default))
     public var currencies: [Currency]
 
-    @SharedReader(.fetchAll(sql: "SELECT * from \(UsageRatePeriod.databaseTableName)", animation: .default))
+    @Fetch(.fetchAll(sql: "SELECT * from \(UsageRatePeriod.databaseTableName)", animation: .default))
     public var usageRatePeriods: [UsageRatePeriod]
 
     var isValid: Bool {

--- a/DeviceValueApp/Sources/AnalyticsFeature/AnalyticsFeature.swift
+++ b/DeviceValueApp/Sources/AnalyticsFeature/AnalyticsFeature.swift
@@ -1,19 +1,19 @@
 import ComposableArchitecture
 import Foundation
 import Models
-import SharingGRDB
+import SQLiteData
 
 @Reducer
 public struct Analytics: Sendable {
   @ObservableState
   public struct State: Equatable, Sendable {
-    @SharedReader(.fetch(PortfolioMetricsRequest()))
+    @Fetch(PortfolioMetricsRequest())
     public var portfolioMetrics: PortfolioMetrics?
-    @SharedReader(.fetch(UsageMetricsRequest()))
+    @Fetch(UsageMetricsRequest())
     public var usage: UsageMetrics?
-    @SharedReader(.fetch(DeviceUsageMetricsRequest()))
+    @Fetch(DeviceUsageMetricsRequest())
     public var devices: [DeviceUsageMetrics] = []
-    @SharedReader(.fetch(DefaultCurrencyRequest()))
+    @Fetch(DefaultCurrencyRequest())
     public var defaultCurrency: String = "$"
 
     public init() {}

--- a/DeviceValueApp/Sources/CurrenciesRatesFeature/CurrenciesRatesFeature.swift
+++ b/DeviceValueApp/Sources/CurrenciesRatesFeature/CurrenciesRatesFeature.swift
@@ -1,7 +1,7 @@
 import ComposableArchitecture
 import Generated
 import Models
-import SharingGRDB
+import SQLiteData
 import UIKit
 
 @Reducer
@@ -58,10 +58,10 @@ public struct CurrenciesRatesFeature: Sendable {
     @Shared(.inMemory("currency_search"))
     var searchTerm: String = ""
 
-    @SharedReader(.fetch(CurrencyRequest()))
+    @Fetch(CurrencyRequest())
     public var currencies: [Currency]
 
-    @SharedReader(.fetchOne(sql: "SELECT COUNT(*) FROM currencies"))
+    @Fetch(.fetchOne(sql: "SELECT COUNT(*) FROM currencies"))
     public var totalCurrenciesCount: Int = 0
 
     public var showingAddCurrency = false

--- a/DeviceValueApp/Sources/CurrenciesRatesFeature/CurrenciesRatesView.swift
+++ b/DeviceValueApp/Sources/CurrenciesRatesFeature/CurrenciesRatesView.swift
@@ -1,7 +1,7 @@
 import ComposableArchitecture
 import Generated
 import Models
-import SharingGRDB
+import SQLiteData
 import SwiftUI
 
 public struct CurrenciesRatesView: View {

--- a/DeviceValueApp/Sources/HomeFeature/HomeFeature.swift
+++ b/DeviceValueApp/Sources/HomeFeature/HomeFeature.swift
@@ -12,7 +12,7 @@ import CurrenciesRatesFeature
 import Generated
 import Models
 import SettingsFeature
-import SharingGRDB
+import SQLiteData
 
 public struct CurrencyCost: FetchableRecord, Decodable, Equatable, Sendable {
   let currencyCode: String
@@ -46,14 +46,14 @@ public struct HomeFeature: Sendable {
     @Presents
     public var destination: Destination.State?
 
-    @SharedReader(.fetch(Items(ordering: .created)))
+    @Fetch(Items(ordering: .created))
     public var devices: [Items.State]
     @Shared(.inMemory("order"))
     var ordering: Ordering = .created
-    @SharedReader(.fetch(Aggregate()))
+    @Fetch(Aggregate())
     public var count: CurrencyCost? = nil
 
-    @SharedReader(.fetch(SettingsFeature.SettingsFetcher()))
+    @Fetch(SettingsFeature.SettingsFetcher())
     public var settingsWithCurrency: AppSettingsWithCurrency = .init()
 
     var path = StackState<Path.State>()

--- a/DeviceValueApp/Sources/SettingsFeature/SettingsFeature.swift
+++ b/DeviceValueApp/Sources/SettingsFeature/SettingsFeature.swift
@@ -7,7 +7,7 @@ import ComposableArchitecture
 import Foundation
 import GRDB
 import Models
-import SharingGRDB
+import SQLiteData
 import UIApplicationClient
 import UIKit
 
@@ -49,10 +49,10 @@ public struct SettingsFeature: Sendable {
 
   @ObservableState
   public struct State: Equatable, Sendable {
-    @SharedReader(.fetch(SettingsFetcher()))
+    @Fetch(SettingsFetcher())
     public var settingsWithCurrency: AppSettingsWithCurrency = .init()
 
-    @SharedReader(.fetchAll(sql: "SELECT * from currencies ORDER BY code = 'USD' DESC, name", animation: .default))
+    @Fetch(.fetchAll(sql: "SELECT * from currencies ORDER BY code = 'USD' DESC, name", animation: .default))
     public var availableCurrencies: [Currency]
 
     public var presentation = SettingsPresentation(


### PR DESCRIPTION
Updated dependencies and code to use the new Point-Free SQLiteData library:

- Updated Package.swift to use sqlite-data v1.3.0 instead of sharing-grdb v0.1.0
- Replaced all SharingGRDB product references with SQLiteData in target dependencies
- Changed all import statements from `import SharingGRDB` to `import SQLiteData`
- Replaced all @SharedReader property wrappers with @Fetch property wrappers
- Maintained all existing FetchKeyRequest implementations (compatible with sqlite-data)
- No changes to database schema or SQL queries required

This migration updates to the officially renamed package. The sharing-grdb repository has been archived by Point-Free and all future development will happen in the sqlite-data repository.

Files modified:
- DeviceValueApp/Package.swift
- DeviceValue/DeviceValue/FinancialFlowApp.swift
- DeviceValueApp/Sources/AddDeviceFeature/AddDeviceFeature.swift
- DeviceValueApp/Sources/AnalyticsFeature/AnalyticsFeature.swift
- DeviceValueApp/Sources/CurrenciesRatesFeature/CurrenciesRatesFeature.swift
- DeviceValueApp/Sources/CurrenciesRatesFeature/CurrenciesRatesView.swift
- DeviceValueApp/Sources/HomeFeature/HomeFeature.swift
- DeviceValueApp/Sources/SettingsFeature/SettingsFeature.swift